### PR TITLE
位置情報偽装機能のUIと到達した市町村を保存するデータベースの実装

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,9 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.compiler)
 
     implementation(libs.google.play.services.maps)
     implementation(libs.google.play.services.maps.compose)
@@ -89,6 +92,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.play.services.location)
 
+    ksp(libs.androidx.room.compiler)
     ksp(libs.hilt.android.compiler)
 
     testImplementation(libs.junit)

--- a/app/src/main/java/com/punyo/slatemap/application/GeoJsonLayerGenerator.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/GeoJsonLayerGenerator.kt
@@ -5,36 +5,79 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.JointType
 import com.google.maps.android.data.geojson.GeoJsonLayer
 import com.punyo.slatemap.R
+import com.punyo.slatemap.application.constant.GeoJsonPropertyNameConstants
 
 class GeoJsonLayerGenerator(
     private val map: GoogleMap,
     private val currentUserRegion: Regions,
 ) {
-    fun generateGeoJsonLayer(context: Context) {
+    private var currentHokkaidoLayer: GeoJsonLayer? = null
+    private var currentTohokuLayer: GeoJsonLayer? = null
+    private var currentKantoAndChubuLayer: GeoJsonLayer? = null
+    private var currentKinkiAndChugokuLayer: GeoJsonLayer? = null
+    private var currentShikokuLayer: GeoJsonLayer? = null
+    private var currentKyushuAndOkinawaLayer: GeoJsonLayer? = null
+
+    fun generateGeoJsonLayer(
+        context: Context,
+        unlockedLocalityInRegion: List<String>,
+    ) {
         for (region in Regions.entries) {
+            val layer: GeoJsonLayer
             if (region != currentUserRegion) {
-                val layer =
-                    GeoJsonLayer(map, getCombinedGeoJsonResourceIdFromRegion(region), context)
+                layer = GeoJsonLayer(map, getCombinedGeoJsonResourceIdFromRegion(region), context)
                 layer.defaultPolygonStyle.apply {
                     fillColor = context.getColor(R.color.geoJsonLayer_combined_fillColor)
                     strokeColor = context.getColor(R.color.geoJsonLayer_combined_strokeColor)
                     strokeWidth = 7.5f
                     strokeJointType = JointType.BEVEL
                 }
-                layer.addLayerToMap()
             } else {
-                val layer =
-                    GeoJsonLayer(map, getGeoJsonResourceIdFromRegion(region), context)
+                layer = GeoJsonLayer(map, getGeoJsonResourceIdFromRegion(region), context)
                 layer.defaultPolygonStyle.apply {
                     fillColor = context.getColor(R.color.geoJsonLayer_fillColor)
                     strokeColor = context.getColor(R.color.geoJsonLayer_strokeColor)
                     strokeWidth = 5f
                     strokeJointType = JointType.BEVEL
                 }
-                layer.addLayerToMap()
+                unlockedLocalityInRegion.forEach { localityName ->
+                    layer.removeFeature(
+                        layer.features.filter {
+                            it.getProperty(
+                                GeoJsonPropertyNameConstants.CITY_OR_TOKYO_SPECIAL_WARD,
+                            ) == localityName
+                        }[0],
+                    )
+                }
             }
+            setGeoJsonLayer(layer, region)
         }
     }
+
+    private fun setGeoJsonLayer(
+        layer: GeoJsonLayer,
+        region: Regions,
+    ) {
+        when (region) {
+            Regions.HOKKAIDO -> currentHokkaidoLayer = layer
+            Regions.TOHOKU -> currentTohokuLayer = layer
+            Regions.KANTO_AND_CHUBU -> currentKantoAndChubuLayer = layer
+            Regions.KINKI_AND_CHUGOKU -> currentKinkiAndChugokuLayer = layer
+            Regions.SHIKOKU -> currentShikokuLayer = layer
+            Regions.KYUSHU_AND_OKINAWA -> currentKyushuAndOkinawaLayer = layer
+        }
+        layer.addLayerToMap()
+    }
+
+    fun getGeoJsonLayer(region: Regions): GeoJsonLayer? =
+        when (region) {
+            Regions.HOKKAIDO -> currentHokkaidoLayer
+            Regions.TOHOKU -> currentTohokuLayer
+            Regions.KANTO_AND_CHUBU -> currentKantoAndChubuLayer
+            Regions.KINKI_AND_CHUGOKU -> currentKinkiAndChugokuLayer
+            Regions.SHIKOKU -> currentShikokuLayer
+            Regions.KYUSHU_AND_OKINAWA -> currentKyushuAndOkinawaLayer
+        }
 
     private fun getGeoJsonResourceIdFromRegion(region: Regions): Int =
         when (region) {

--- a/app/src/main/java/com/punyo/slatemap/application/GeoJsonLayerGenerator.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/GeoJsonLayerGenerator.kt
@@ -1,0 +1,58 @@
+package com.punyo.slatemap.application
+
+import android.content.Context
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.JointType
+import com.google.maps.android.data.geojson.GeoJsonLayer
+import com.punyo.slatemap.R
+
+class GeoJsonLayerGenerator(
+    private val map: GoogleMap,
+    private val currentUserRegion: Regions,
+) {
+    fun generateGeoJsonLayer(context: Context) {
+        for (region in Regions.entries) {
+            if (region != currentUserRegion) {
+                val layer =
+                    GeoJsonLayer(map, getCombinedGeoJsonResourceIdFromRegion(region), context)
+                layer.defaultPolygonStyle.apply {
+                    fillColor = context.getColor(R.color.geoJsonLayer_combined_fillColor)
+                    strokeColor = context.getColor(R.color.geoJsonLayer_combined_strokeColor)
+                    strokeWidth = 7.5f
+                    strokeJointType = JointType.BEVEL
+                }
+                layer.addLayerToMap()
+            } else {
+                val layer =
+                    GeoJsonLayer(map, getGeoJsonResourceIdFromRegion(region), context)
+                layer.defaultPolygonStyle.apply {
+                    fillColor = context.getColor(R.color.geoJsonLayer_fillColor)
+                    strokeColor = context.getColor(R.color.geoJsonLayer_strokeColor)
+                    strokeWidth = 5f
+                    strokeJointType = JointType.BEVEL
+                }
+                layer.addLayerToMap()
+            }
+        }
+    }
+
+    private fun getGeoJsonResourceIdFromRegion(region: Regions): Int =
+        when (region) {
+            Regions.HOKKAIDO -> R.raw.hokkaido
+            Regions.TOHOKU -> R.raw.tohoku
+            Regions.KANTO_AND_CHUBU -> R.raw.kanto_and_chubu
+            Regions.KINKI_AND_CHUGOKU -> R.raw.kinki_and_chugoku
+            Regions.SHIKOKU -> R.raw.shikoku
+            Regions.KYUSHU_AND_OKINAWA -> R.raw.kyushu_and_okinawa
+        }
+
+    private fun getCombinedGeoJsonResourceIdFromRegion(region: Regions): Int =
+        when (region) {
+            Regions.HOKKAIDO -> R.raw.hokkaido_combined
+            Regions.TOHOKU -> R.raw.tohoku_combined
+            Regions.KANTO_AND_CHUBU -> R.raw.kanto_and_chubu_combined
+            Regions.KINKI_AND_CHUGOKU -> R.raw.kinki_and_chugoku_combined
+            Regions.SHIKOKU -> R.raw.shikoku_combined
+            Regions.KYUSHU_AND_OKINAWA -> R.raw.kyushu_and_okinawa_combined
+        }
+}

--- a/app/src/main/java/com/punyo/slatemap/application/Regions.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/Regions.kt
@@ -1,0 +1,10 @@
+package com.punyo.slatemap.application
+
+enum class Regions {
+    HOKKAIDO,
+    TOHOKU,
+    KANTO_AND_CHUBU,
+    KINKI_AND_CHUGOKU,
+    SHIKOKU,
+    KYUSHU_AND_OKINAWA,
+}

--- a/app/src/main/java/com/punyo/slatemap/application/db/AppDatabase.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/db/AppDatabase.kt
@@ -1,0 +1,8 @@
+package com.punyo.slatemap.application.db
+
+import androidx.room.RoomDatabase
+import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalityDao
+
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun unlockedLocalityDao(): UnlockedLocalityDao
+}

--- a/app/src/main/java/com/punyo/slatemap/application/db/DatabaseProvider.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/db/DatabaseProvider.kt
@@ -1,0 +1,23 @@
+package com.punyo.slatemap.application.db
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+    private const val DATABASE_NAME = "app_database"
+
+    private var instance: AppDatabase? = null
+
+    fun getDatabase(context: Context): AppDatabase =
+        instance ?: synchronized(this) {
+            val instance =
+                Room
+                    .databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        DATABASE_NAME,
+                    ).build()
+            this.instance = instance
+            instance
+        }
+}

--- a/app/src/main/java/com/punyo/slatemap/application/di/RepositoryModule.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package com.punyo.slatemap.application.di
 
 import com.punyo.slatemap.data.location.LocationRepository
 import com.punyo.slatemap.data.location.LocationRepositoryImpl
+import com.punyo.slatemap.data.unlockedlocality.UnlockedLocalityRepository
+import com.punyo.slatemap.data.unlockedlocality.UnlockedLocalityRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindLocationRepository(locationRepositoryImpl: LocationRepositoryImpl): LocationRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUnlockedLocalityRepository(unlockedLocalityRepositoryImpl: UnlockedLocalityRepositoryImpl): UnlockedLocalityRepository
 }

--- a/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
@@ -2,6 +2,7 @@ package com.punyo.slatemap.application.di
 
 import android.content.Context
 import com.google.android.gms.location.LocationServices
+import com.punyo.slatemap.application.db.DatabaseProvider
 import com.punyo.slatemap.data.location.source.UserLocationSource
 import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalitySource
 import dagger.Module
@@ -22,10 +23,15 @@ object SourceModule {
 
     @Provides
     @Singleton
-    fun provideUnlockedLocalitySource(): UnlockedLocalitySource = UnlockedLocalitySource()
+    fun provideUnlockedLocalitySource(
+        @ApplicationContext context: Context,
+    ): UnlockedLocalitySource =
+        UnlockedLocalitySource(
+            DatabaseProvider.getDatabase(context).unlockedLocalityDao(),
+        )
 
-    @Singleton
     @Provides
+    @Singleton
     fun provideApplicationContext(
         @ApplicationContext applicationContext: Context,
     ): Context = applicationContext

--- a/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
@@ -23,4 +23,10 @@ object SourceModule {
     @Provides
     @Singleton
     fun provideUnlockedLocationSource(): UnlockedLocationSource = UnlockedLocationSource()
+
+    @Singleton
+    @Provides
+    fun provideApplicationContext(
+        @ApplicationContext applicationContext: Context,
+    ): Context = applicationContext
 }

--- a/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
+++ b/app/src/main/java/com/punyo/slatemap/application/di/SourceModule.kt
@@ -2,8 +2,8 @@ package com.punyo.slatemap.application.di
 
 import android.content.Context
 import com.google.android.gms.location.LocationServices
-import com.punyo.slatemap.data.location.source.UnlockedLocationSource
 import com.punyo.slatemap.data.location.source.UserLocationSource
+import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalitySource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,7 +22,7 @@ object SourceModule {
 
     @Provides
     @Singleton
-    fun provideUnlockedLocationSource(): UnlockedLocationSource = UnlockedLocationSource()
+    fun provideUnlockedLocalitySource(): UnlockedLocalitySource = UnlockedLocalitySource()
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/punyo/slatemap/data/location/LocationRepository.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/location/LocationRepository.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.location.Address
 import android.location.Location
 import com.google.android.gms.tasks.Task
+import com.punyo.slatemap.application.Regions
 
 interface LocationRepository {
     fun getLastLocation(): Result<Task<Location>>
+
+    fun addLocationCallback(onLocationUpdate: (Location) -> Unit): Result<Nothing?>
 
     fun setMockLocation(location: Location): Result<Nothing?>
 
@@ -16,4 +19,9 @@ interface LocationRepository {
         context: Context,
         location: Location,
     ): Address
+
+    suspend fun getRegionFromLocation(
+        context: Context,
+        location: Location,
+    ): Regions
 }

--- a/app/src/main/java/com/punyo/slatemap/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/location/LocationRepositoryImpl.kt
@@ -2,14 +2,10 @@ package com.punyo.slatemap.data.location
 
 import android.content.Context
 import android.location.Address
-import android.location.Geocoder
 import android.location.Location
-import android.os.Build
 import com.punyo.slatemap.data.location.source.UnlockedLocationSource
 import com.punyo.slatemap.data.location.source.UserLocationSource
-import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
-import kotlin.coroutines.resume
 
 class LocationRepositoryImpl
     @Inject
@@ -22,25 +18,19 @@ class LocationRepositoryImpl
 
         override fun getLastLocation() = userLocationSource.getLastLocation()
 
+        override fun addLocationCallback(onLocationUpdate: (Location) -> Unit) = userLocationSource.addLocationCallback(onLocationUpdate)
+
         override fun setMockLocation(location: Location) = userLocationSource.setMockLocation(location)
 
         override fun clearMockLocation() = userLocationSource.clearMockLocation()
 
-        @Suppress("DEPRECATION")
         override suspend fun getAddressFromLocation(
             context: Context,
             location: Location,
-        ): Address =
-            suspendCancellableCoroutine { continuation ->
-                val geocoder = Geocoder(context)
-                if (Build.VERSION.SDK_INT < 33) {
-                    continuation.resume(
-                        geocoder.getFromLocation(location.latitude, location.longitude, 1)!![0],
-                    )
-                } else {
-                    geocoder.getFromLocation(location.latitude, location.longitude, 1) { addresses ->
-                        continuation.resume(addresses[0])
-                    }
-                }
-            }
+        ): Address = userLocationSource.getAddressFromLocation(context, location)
+
+        override suspend fun getRegionFromLocation(
+            context: Context,
+            location: Location,
+        ) = userLocationSource.getRegionFromLocation(context, location)
     }

--- a/app/src/main/java/com/punyo/slatemap/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/location/LocationRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.punyo.slatemap.data.location
 import android.content.Context
 import android.location.Address
 import android.location.Location
-import com.punyo.slatemap.data.location.source.UnlockedLocationSource
 import com.punyo.slatemap.data.location.source.UserLocationSource
 import javax.inject.Inject
 
@@ -12,9 +11,6 @@ class LocationRepositoryImpl
     constructor() : LocationRepository {
         @Inject
         lateinit var userLocationSource: UserLocationSource
-
-        @Inject
-        lateinit var unlockedLocationSource: UnlockedLocationSource
 
         override fun getLastLocation() = userLocationSource.getLastLocation()
 

--- a/app/src/main/java/com/punyo/slatemap/data/location/source/UnlockedLocationSource.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/location/source/UnlockedLocationSource.kt
@@ -1,3 +1,0 @@
-package com.punyo.slatemap.data.location.source
-
-class UnlockedLocationSource

--- a/app/src/main/java/com/punyo/slatemap/data/location/source/UserLocationSource.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/location/source/UserLocationSource.kt
@@ -1,12 +1,48 @@
 package com.punyo.slatemap.data.location.source
 
+import android.Manifest
+import android.content.Context
+import android.location.Address
+import android.location.Geocoder
 import android.location.Location
+import android.os.Build
+import android.os.Looper
+import androidx.annotation.RequiresPermission
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.Task
+import com.punyo.slatemap.R
+import com.punyo.slatemap.application.Regions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 class UserLocationSource(
     private val fusedLocationProviderClient: FusedLocationProviderClient,
 ) {
+    private val onLocationUpdateCallbacks = mutableListOf<(Location) -> Unit>()
+    private var currentMockingLocation: Location? = null
+    private var currentMockingJob: Job? = null
+
+    private val locationCallback: LocationCallback =
+        object : LocationCallback() {
+            override fun onLocationResult(locationResult: LocationResult) {
+                super.onLocationResult(locationResult)
+                onLocationUpdateCallbacks.forEach { callback ->
+                    locationResult.lastLocation?.let { callback(it) }
+                }
+            }
+        }
+    private val scope = CoroutineScope(Dispatchers.IO)
+
     fun getLastLocation(): Result<Task<Location>> =
         try {
             Result.success(fusedLocationProviderClient.lastLocation)
@@ -14,20 +50,117 @@ class UserLocationSource(
             Result.failure(e)
         }
 
-    fun setMockLocation(location: Location): Result<Nothing?> =
+    fun addLocationCallback(onLocationUpdate: (Location) -> Unit): Result<Nothing?> =
         try {
-            fusedLocationProviderClient.setMockMode(true)
-            fusedLocationProviderClient.setMockLocation(location)
+            if (onLocationUpdateCallbacks.isEmpty()) {
+                startLocationCallback()
+            }
+            onLocationUpdateCallbacks.add(onLocationUpdate)
             Result.success(null)
         } catch (e: SecurityException) {
             Result.failure(e)
         }
 
-    fun clearMockLocation(): Result<Nothing?> =
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+    private fun startLocationCallback() {
+        val locationRequest =
+            LocationRequest
+                .Builder(
+                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                    LOCATION_UPDATE_INTERVAL,
+                ).setWaitForAccurateLocation(true)
+                .build()
+        fusedLocationProviderClient.requestLocationUpdates(
+            locationRequest,
+            locationCallback,
+            Looper.getMainLooper(),
+        )
+    }
+
+    fun setMockLocation(location: Location): Result<Nothing?> =
         try {
-            fusedLocationProviderClient.setMockMode(false)
+            fusedLocationProviderClient.setMockMode(true)
+            fusedLocationProviderClient.setMockLocation(location)
+            currentMockingLocation = location
+            if (currentMockingJob == null) {
+                currentMockingJob =
+                    scope.launch {
+                        mockingLocationUpdate()
+                    }
+            }
             Result.success(null)
         } catch (e: SecurityException) {
             Result.failure(e)
         }
+
+    private suspend fun CoroutineScope.mockingLocationUpdate() {
+        while (isActive) {
+            onLocationUpdateCallbacks.forEach { callback ->
+                currentMockingLocation.let {
+                    it?.let { callback(it) }
+                }
+            }
+            delay(LOCATION_UPDATE_INTERVAL)
+        }
+    }
+
+    fun clearMockLocation(): Result<Nothing?> =
+        try {
+            fusedLocationProviderClient.setMockMode(false)
+            currentMockingJob?.cancel()
+            currentMockingJob = null
+            Result.success(null)
+        } catch (e: SecurityException) {
+            Result.failure(e)
+        }
+
+    suspend fun getRegionFromLocation(
+        context: Context,
+        location: Location,
+    ): Regions {
+        val hokkaido = context.resources.getStringArray(R.array.hokkaido)
+        val tohoku = context.resources.getStringArray(R.array.tohoku)
+        val kantoAndChubu = context.resources.getStringArray(R.array.kanto_and_chubu)
+        val kinkiAndChugoku = context.resources.getStringArray(R.array.kinki_and_chugoku)
+        val shikoku = context.resources.getStringArray(R.array.shikoku)
+        val kyushuAndOkinawa = context.resources.getStringArray(R.array.kyushu_and_okinawa)
+        val admin = getAddressFromLocation(context, location).adminArea
+        val region =
+            when {
+                hokkaido.contains(admin) -> Regions.HOKKAIDO
+                tohoku.contains(admin) -> Regions.TOHOKU
+                kantoAndChubu.contains(admin) -> Regions.KANTO_AND_CHUBU
+                kinkiAndChugoku.contains(admin) -> Regions.KINKI_AND_CHUGOKU
+                shikoku.contains(admin) -> Regions.SHIKOKU
+                kyushuAndOkinawa.contains(admin) -> Regions.KYUSHU_AND_OKINAWA
+                else -> throw IllegalArgumentException("Unknown prefecture: $admin")
+            }
+        return region
+    }
+
+    @Suppress("DEPRECATION")
+    suspend fun getAddressFromLocation(
+        context: Context,
+        location: Location,
+    ): Address =
+        suspendCancellableCoroutine { continuation ->
+            val geocoder = Geocoder(context)
+            if (Build.VERSION.SDK_INT < 33) {
+                continuation.resume(
+                    geocoder.getFromLocation(location.latitude, location.longitude, 1)!![0],
+                )
+            } else {
+                geocoder.getFromLocation(
+                    location.latitude,
+                    location.longitude,
+                    1,
+                ) { addresses ->
+                    continuation.resume(addresses[0])
+                }
+            }
+        }
+
+    companion object {
+        private const val LOCATION_UPDATE_INTERVAL = 1000L
+    }
 }

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocality.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocality.kt
@@ -1,0 +1,3 @@
+package com.punyo.slatemap.data.unlockedlocality
+
+interface UnlockedLocality

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocality.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocality.kt
@@ -1,3 +1,0 @@
-package com.punyo.slatemap.data.unlockedlocality
-
-interface UnlockedLocality

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityImpl.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityImpl.kt
@@ -1,3 +1,0 @@
-package com.punyo.slatemap.data.unlockedlocality
-
-class UnlockedLocalityImpl : UnlockedLocality

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityImpl.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityImpl.kt
@@ -1,0 +1,3 @@
+package com.punyo.slatemap.data.unlockedlocality
+
+class UnlockedLocalityImpl : UnlockedLocality

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityRepository.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityRepository.kt
@@ -1,0 +1,17 @@
+package com.punyo.slatemap.data.unlockedlocality
+
+import com.punyo.slatemap.application.Regions
+import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalityEntity
+
+interface UnlockedLocalityRepository {
+    suspend fun deleteAllUnlockedLocalities()
+
+    suspend fun getUnlockedLocalityByRegion(region: Regions): List<UnlockedLocalityEntity>
+
+    suspend fun insertUnlockedLocality(unlockedLocality: UnlockedLocalityEntity)
+
+    suspend fun isLocalityUnlocked(
+        region: Regions,
+        localityName: String,
+    ): Boolean
+}

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityRepositoryImpl.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/UnlockedLocalityRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.punyo.slatemap.data.unlockedlocality
+
+import com.punyo.slatemap.application.Regions
+import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalityEntity
+import com.punyo.slatemap.data.unlockedlocality.source.UnlockedLocalitySource
+import javax.inject.Inject
+
+class UnlockedLocalityRepositoryImpl
+    @Inject
+    constructor(
+        private val unlockedLocalitySource: UnlockedLocalitySource,
+    ) : UnlockedLocalityRepository {
+        override suspend fun deleteAllUnlockedLocalities() = unlockedLocalitySource.deleteAllUnlockedLocalities()
+
+        override suspend fun getUnlockedLocalityByRegion(region: Regions) = unlockedLocalitySource.getUnlockedLocalityByRegion(region)
+
+        override suspend fun insertUnlockedLocality(unlockedLocality: UnlockedLocalityEntity) =
+            unlockedLocalitySource.insertUnlockedLocality(unlockedLocality)
+
+        override suspend fun isLocalityUnlocked(
+            region: Regions,
+            localityName: String,
+        ) = unlockedLocalitySource.isLocalityUnlocked(region, localityName)
+    }

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalityDao.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalityDao.kt
@@ -1,0 +1,18 @@
+package com.punyo.slatemap.data.unlockedlocality.source
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface UnlockedLocalityDao {
+    @Query("SELECT * FROM unlocked_locality WHERE region = :regions")
+    suspend fun getUnlockedLocalityByRegion(regions: String): List<UnlockedLocalityEntity>
+
+    @Query("DELETE FROM unlocked_locality")
+    suspend fun deleteAllUnlockedLocality()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUnlockedLocality(unlockedLocality: UnlockedLocalityEntity)
+}

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalityEntity.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalityEntity.kt
@@ -1,0 +1,11 @@
+package com.punyo.slatemap.data.unlockedlocality.source
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "unlocked_locality")
+data class UnlockedLocalityEntity(
+    @PrimaryKey val localityName: String,
+    val unlockedDate: String,
+    val region: String,
+)

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalitySource.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalitySource.kt
@@ -1,3 +1,23 @@
 package com.punyo.slatemap.data.unlockedlocality.source
 
-class UnlockedLocalitySource
+import com.punyo.slatemap.application.Regions
+
+class UnlockedLocalitySource(
+    private val unlockedLocalityDao: UnlockedLocalityDao,
+) {
+    suspend fun deleteAllUnlockedLocalities() = unlockedLocalityDao.deleteAllUnlockedLocality()
+
+    suspend fun getUnlockedLocalityByRegion(region: Regions): List<UnlockedLocalityEntity> =
+        unlockedLocalityDao.getUnlockedLocalityByRegion(region.toString())
+
+    suspend fun insertUnlockedLocality(unlockedLocality: UnlockedLocalityEntity) =
+        unlockedLocalityDao.insertUnlockedLocality(unlockedLocality)
+
+    suspend fun isLocalityUnlocked(
+        region: Regions,
+        localityName: String,
+    ): Boolean =
+        unlockedLocalityDao.getUnlockedLocalityByRegion(region.toString()).any {
+            it.localityName == localityName
+        }
+}

--- a/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalitySource.kt
+++ b/app/src/main/java/com/punyo/slatemap/data/unlockedlocality/source/UnlockedLocalitySource.kt
@@ -1,0 +1,3 @@
+package com.punyo.slatemap.data.unlockedlocality.source
+
+class UnlockedLocalitySource

--- a/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
@@ -32,7 +32,7 @@ fun MapScreen(
     val currentState by mapScreenViewModel.uiState.collectAsStateWithLifecycle()
     val style =
         remember { mutableStateOf(MapStyleOptions.loadRawResourceStyle(context, R.raw.style)) }
-    if (currentState.currentLocation != null && currentState.currentRegion != null) {
+    if (currentState.currentLocation != null && currentState.currentRegion != null && currentState.currentLocalityName != null) {
         GoogleMap(
             modifier = modifier,
             properties =
@@ -53,7 +53,10 @@ fun MapScreen(
                 GeoJsonLayerGenerator(
                     map = map,
                     currentUserRegion = currentState.currentRegion!!,
-                ).generateGeoJsonLayer(context = context)
+                ).generateGeoJsonLayer(
+                    context = context,
+                    unlockedLocalityInRegion = listOf(currentState.currentLocalityName!!),
+                )
             })
             Polygon(
                 points =

--- a/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package com.punyo.slatemap.ui.map
 
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,39 +32,43 @@ fun MapScreen(
     val currentState by mapScreenViewModel.uiState.collectAsStateWithLifecycle()
     val style =
         remember { mutableStateOf(MapStyleOptions.loadRawResourceStyle(context, R.raw.style)) }
-    GoogleMap(
-        modifier = modifier,
-        properties =
-            MapProperties(
-                minZoomPreference = 5.5f,
-                latLngBoundsForCameraTarget = LatLngConstants.japanBoundsForCameraTarget,
-            ),
-        uiSettings =
-            MapUiSettings(
-                compassEnabled = true,
-                mapToolbarEnabled = true,
-                myLocationButtonEnabled = true,
-            ),
-        cameraPositionState = currentState.cameraPosition,
-    ) {
-        MapEffect(block = { map ->
-            map.setMapStyle(style.value)
-            currentState.currentRegion?.let {
+    if (currentState.currentLocation != null && currentState.currentRegion != null) {
+        GoogleMap(
+            modifier = modifier,
+            properties =
+                MapProperties(
+                    minZoomPreference = 5.5f,
+                    latLngBoundsForCameraTarget = LatLngConstants.japanBoundsForCameraTarget,
+                ),
+            uiSettings =
+                MapUiSettings(
+                    compassEnabled = true,
+                    mapToolbarEnabled = true,
+                    myLocationButtonEnabled = true,
+                ),
+            cameraPositionState = currentState.cameraPosition,
+        ) {
+            MapEffect(block = { map ->
+                map.setMapStyle(style.value)
                 GeoJsonLayerGenerator(
                     map = map,
-                    currentUserRegion = it,
+                    currentUserRegion = currentState.currentRegion!!,
                 ).generateGeoJsonLayer(context = context)
-            }
-        })
-        Polygon(
-            points =
-                LatLngConstants.northernHemisphere,
-            holes =
-                listOf(LatLngConstants.japanBoundsForPolygonHole),
-            fillColor = Color.Black,
-            strokeColor = Color.DarkGray,
-            strokeJointType = JointType.BEVEL,
-            strokeWidth = 50f,
+            })
+            Polygon(
+                points =
+                    LatLngConstants.northernHemisphere,
+                holes =
+                    listOf(LatLngConstants.japanBoundsForPolygonHole),
+                fillColor = Color.Black,
+                strokeColor = Color.DarkGray,
+                strokeJointType = JointType.BEVEL,
+                strokeWidth = 50f,
+            )
+        }
+    } else {
+        CircularProgressIndicator(
+            modifier = modifier,
         )
     }
 }

--- a/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/punyo/slatemap/ui/map/MapScreen.kt
@@ -1,6 +1,7 @@
 package com.punyo.slatemap.ui.map
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -16,8 +17,8 @@ import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.MapsComposeExperimentalApi
 import com.google.maps.android.compose.Polygon
-import com.google.maps.android.data.geojson.GeoJsonLayer
 import com.punyo.slatemap.R
+import com.punyo.slatemap.application.GeoJsonLayerGenerator
 import com.punyo.slatemap.application.constant.LatLngConstants
 
 @OptIn(MapsComposeExperimentalApi::class)
@@ -27,7 +28,7 @@ fun MapScreen(
     mapScreenViewModel: MapScreenViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val currentState = mapScreenViewModel.uiState.collectAsStateWithLifecycle()
+    val currentState by mapScreenViewModel.uiState.collectAsStateWithLifecycle()
     val style =
         remember { mutableStateOf(MapStyleOptions.loadRawResourceStyle(context, R.raw.style)) }
     GoogleMap(
@@ -43,26 +44,16 @@ fun MapScreen(
                 mapToolbarEnabled = true,
                 myLocationButtonEnabled = true,
             ),
-        cameraPositionState = currentState.value.cameraPosition,
+        cameraPositionState = currentState.cameraPosition,
     ) {
         MapEffect(block = { map ->
             map.setMapStyle(style.value)
-            val layer =
-                GeoJsonLayer(map, R.raw.kanto_and_chubu, context)
-            layer.features
-                .filter { feature ->
-                    feature.getProperty("N03_003") == "名古屋市"
-                }.forEach { layer.removeFeature(it) }
-            layer.defaultPolygonStyle.apply {
-                fillColor = 0xff000000.toInt()
-                strokeColor = 0xff000064.toInt()
-                strokeWidth = 5f
-                strokeJointType = JointType.BEVEL
+            currentState.currentRegion?.let {
+                GeoJsonLayerGenerator(
+                    map = map,
+                    currentUserRegion = it,
+                ).generateGeoJsonLayer(context = context)
             }
-            layer.setOnFeatureClickListener { feature ->
-                feature.geometry
-            }
-            layer.addLayerToMap()
         })
         Polygon(
             points =

--- a/app/src/main/java/com/punyo/slatemap/ui/map/MapScreenViewModel.kt
+++ b/app/src/main/java/com/punyo/slatemap/ui/map/MapScreenViewModel.kt
@@ -35,6 +35,8 @@ class MapScreenViewModel
 
         private fun onLocationGetSuccess(location: Location?) {
             viewModelScope.launch {
+                val address =
+                    location?.let { locationRepository.getAddressFromLocation(applicationContext, it) }
                 val region =
                     location?.let {
                         locationRepository.getRegionFromLocation(
@@ -46,6 +48,7 @@ class MapScreenViewModel
                     state.value.copy(
                         currentLocation = location,
                         currentRegion = region,
+                        currentLocalityName = address?.locality,
                     )
             }
         }
@@ -66,6 +69,8 @@ class MapScreenViewModel
 data class MapScreenUiState(
     val currentLocation: Location? = null,
     val currentRegion: Regions? = null,
+    val currentLocalityName: String? = null,
+    val unlockedLocationsIdInCurrentRegion: List<Int>? = null,
     val cameraPosition: CameraPositionState =
         CameraPositionState(
             position =

--- a/app/src/main/java/com/punyo/slatemap/ui/map/MapScreenViewModel.kt
+++ b/app/src/main/java/com/punyo/slatemap/ui/map/MapScreenViewModel.kt
@@ -1,40 +1,53 @@
 package com.punyo.slatemap.ui.map
 
+import android.content.Context
 import android.location.Location
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState
+import com.punyo.slatemap.application.Regions
 import com.punyo.slatemap.data.location.LocationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MapScreenViewModel
     @Inject
     constructor(
-        locationRepository: LocationRepository,
+        private val locationRepository: LocationRepository,
+        private val applicationContext: Context,
     ) : ViewModel() {
         private val state = MutableStateFlow(MapScreenUiState())
         val uiState: StateFlow<MapScreenUiState> = state.asStateFlow()
 
         init {
             locationRepository
-                .getLastLocation()
-                .onSuccess { it ->
-                    it.addOnSuccessListener { onLocationGetSuccess(it) }
-                }
+                .addLocationCallback(
+                    onLocationUpdate = { location -> onLocationGetSuccess(location) },
+                )
         }
 
         private fun onLocationGetSuccess(location: Location?) {
-            state.value =
-                state.value.copy(
-                    currentLocation = location,
-                    cameraPosition = getCameraPositionState(location),
-                )
+            viewModelScope.launch {
+                val region =
+                    location?.let {
+                        locationRepository.getRegionFromLocation(
+                            location = it,
+                            context = applicationContext,
+                        )
+                    }
+                state.value =
+                    state.value.copy(
+                        currentLocation = location,
+                        currentRegion = region,
+                    )
+            }
         }
 
         private fun getCameraPositionState(location: Location?) =
@@ -52,6 +65,7 @@ class MapScreenViewModel
 
 data class MapScreenUiState(
     val currentLocation: Location? = null,
+    val currentRegion: Regions? = null,
     val cameraPosition: CameraPositionState =
         CameraPositionState(
             position =

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="hokkaido">
+        <item>北海道</item>
+    </string-array>
+    <string-array name="tohoku">
+        <item>青森県</item>
+        <item>岩手県</item>
+        <item>宮城県</item>
+        <item>秋田県</item>
+        <item>山形県</item>
+        <item>福島県</item>
+    </string-array>
+    <string-array name="kanto_and_chubu">
+        <item>茨城県</item>
+        <item>栃木県</item>
+        <item>群馬県</item>
+        <item>埼玉県</item>
+        <item>千葉県</item>
+        <item>東京都</item>
+        <item>神奈川県</item>
+        <item>新潟県</item>
+        <item>富山県</item>
+        <item>石川県</item>
+        <item>福井県</item>
+        <item>山梨県</item>
+        <item>長野県</item>
+        <item>岐阜県</item>
+        <item>静岡県</item>
+        <item>愛知県</item>
+    </string-array>
+    <string-array name="kinki_and_chugoku">
+        <item>三重県</item>
+        <item>滋賀県</item>
+        <item>京都府</item>
+        <item>大阪府</item>
+        <item>兵庫県</item>
+        <item>奈良県</item>
+        <item>和歌山県</item>
+        <item>鳥取県</item>
+        <item>島根県</item>
+        <item>岡山県</item>
+        <item>広島県</item>
+        <item>山口県</item>
+    </string-array>
+    <string-array name="shikoku">
+        <item>徳島県</item>
+        <item>香川県</item>
+        <item>愛媛県</item>
+        <item>高知県</item>
+    </string-array>
+    <string-array name="kyushu_and_okinawa">
+        <item>福岡県</item>
+        <item>佐賀県</item>
+        <item>長崎県</item>
+        <item>熊本県</item>
+        <item>大分県</item>
+        <item>宮崎県</item>
+        <item>鹿児島県</item>
+        <item>沖縄県</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,9 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="geoJsonLayer_fillColor">#ff000000</color>
+    <color name="geoJsonLayer_strokeColor">#ff000064</color>
+    <color name="geoJsonLayer_combined_fillColor">#ff000000</color>
+    <color name="geoJsonLayer_combined_strokeColor">#ff640000</color>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.03.01"
 googlePlayServicesMaps = "19.1.0"
+room = "2.7.0"
 googlePlayServicesMapsCompose = "6.1.0"
 mapsUtilsKtx = "5.1.1"
 secretsGradlePlugin = "2.0.1"
@@ -38,6 +39,9 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 
 google-play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "googlePlayServicesMaps" }
 google-play-services-maps-compose = { group = "com.google.maps.android", name = "maps-compose", version.ref = "googlePlayServicesMapsCompose" }


### PR DESCRIPTION
# 概要
位置情報偽装機能のUIと到達した市町村を保存するデータベースの実装を行った。

# 細かな変更点
- Roomの導入
- 位置情報を偽造するためのDebugScreenの実装
- 到達した市町村を保存するデータベースを実装
- GeoJsonLayerGeneratorから指定した市町村のFeatureを削除する機能を実装

# 既存の箇所への影響範囲
- MapScreenのGeoJsonLayerを追加する部分
- DebugScreenすべて